### PR TITLE
Restore followed users and starred repos on repositories page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -552,8 +552,24 @@ jekyll_get_json:
     json: assets/json/resume.json # it can also be an url
   - data: github_user_PaulRoze
     json: https://api.github.com/users/PaulRoze
+  - data: github_user_momowind-su
+    json: https://api.github.com/users/momowind-su
+  - data: github_user_antonbabenko
+    json: https://api.github.com/users/antonbabenko
+  - data: github_user_geerlingguy
+    json: https://api.github.com/users/geerlingguy
   - data: github_repo_PaulRoze_mezeze
     json: https://api.github.com/repos/PaulRoze/mezeze
+  - data: github_repo_momowind-su_Satoru-Gojo-NVIM
+    json: https://api.github.com/repos/momowind-su/Satoru-Gojo-NVIM
+  - data: github_repo_github_gitignore
+    json: https://api.github.com/repos/github/gitignore
+  - data: github_repo_antonbabenko_terraform-best-practices
+    json: https://api.github.com/repos/antonbabenko/terraform-best-practices
+  - data: github_repo_Netflix_chaosmonkey
+    json: https://api.github.com/repos/Netflix/chaosmonkey
+  - data: github_repo_junegunn_fzf
+    json: https://api.github.com/repos/junegunn/fzf
 jsonresume:
   - basics
   - work

--- a/_data/repositories.yml
+++ b/_data/repositories.yml
@@ -1,5 +1,13 @@
 github_users:
   - PaulRoze
+  - momowind-su
+  - antonbabenko
+  - geerlingguy
 
 github_repos:
   - PaulRoze/mezeze
+  - momowind-su/Satoru-Gojo-NVIM
+  - github/gitignore
+  - antonbabenko/terraform-best-practices
+  - Netflix/chaosmonkey
+  - junegunn/fzf


### PR DESCRIPTION
## Summary

- Restore `repositories.yml` with all 4 GitHub users and 6 repos that were mistakenly removed
- Add `jekyll-get-json` entries in `_config.yml` to fetch GitHub API data at build time for all users and repos

## What was wrong

The previous commit stripped the repos page to only show PaulRoze/mezeze. The original data (followed users and starred repos) should have been kept — they represent people I follow and projects I find interesting.

## Visually verified

Tested with Docker — all 4 user cards and 6 repo cards render correctly with avatars, bios, descriptions, stars, forks, and language indicators.

## Test plan

- [ ] CI checks pass (deploy, prettier, link-checker)
- [ ] Repositories page shows 4 users and 6 repos
- [ ] All cards render with real GitHub data (no broken images)

🤖 Generated with [Claude Code](https://claude.com/claude-code)