### PR TITLE
Replace Node.js 20 action with sed to fix deprecation warning

### DIFF
--- a/.github/workflows/axe.yml
+++ b/.github/workflows/axe.yml
@@ -35,15 +35,9 @@ jobs:
           ruby-version: "3.2.2"
           bundler-cache: true
       - name: Update _config.yml
-        uses: fjogeleit/yaml-update-action@v0.16.1
-        with:
-          commitChange: false
-          valueFile: "_config.yml"
-          changes: |
-            {
-              "giscus.repo": "${{ github.repository }}",
-              "baseurl": ""
-            }
+        run: |
+          sed -i "s|^  repo:.*|  repo: ${{ github.repository }}|" _config.yml
+          sed -i "s|^baseurl:.*|baseurl: |" _config.yml
       - name: Install and Build
         run: |
           pip3 install --upgrade jupyter

--- a/.github/workflows/broken-links-site.yml
+++ b/.github/workflows/broken-links-site.yml
@@ -20,15 +20,9 @@ jobs:
           ruby-version: "3.2.2"
           bundler-cache: true
       - name: Update _config.yml
-        uses: fjogeleit/yaml-update-action@v0.16.1
-        with:
-          commitChange: false
-          valueFile: "_config.yml"
-          changes: |
-            {
-              "giscus.repo": "${{ github.repository }}",
-              "baseurl": ""
-            }
+        run: |
+          sed -i "s|^  repo:.*|  repo: ${{ github.repository }}|" _config.yml
+          sed -i "s|^baseurl:.*|baseurl: |" _config.yml
       - name: Install and Build
         run: |
           pip3 install --upgrade jupyter

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,9 +14,6 @@ on:
       - "**.yml"
       - "!.github/workflows/axe.yml"
       - "!.github/workflows/broken-links.yml"
-      - "!.github/workflows/deploy-docker-tag.yml"
-      - "!.github/workflows/deploy-image.yml"
-      - "!.github/workflows/docker-slim.yml"
       - "!.github/workflows/lighthouse-badger.yml"
       - "!.github/workflows/prettier.yml"
       - "!lighthouse_results/**"
@@ -38,9 +35,6 @@ on:
       - "**.yml"
       - "!.github/workflows/axe.yml"
       - "!.github/workflows/broken-links.yml"
-      - "!.github/workflows/deploy-docker-tag.yml"
-      - "!.github/workflows/deploy-image.yml"
-      - "!.github/workflows/docker-slim.yml"
       - "!.github/workflows/lighthouse-badger.yml"
       - "!.github/workflows/prettier.yml"
       - "!lighthouse_results/**"
@@ -67,12 +61,8 @@ jobs:
           ruby-version: "3.2.2"
           bundler-cache: true
       - name: Update _config.yml
-        uses: fjogeleit/yaml-update-action@v0.16.1
-        with:
-          commitChange: false
-          valueFile: "_config.yml"
-          propertyPath: "giscus.repo"
-          value: ${{ github.repository }}
+        run: |
+          sed -i "s|^  repo:.*|  repo: ${{ github.repository }}|" _config.yml
       - name: Install and Build
         run: |
           pip3 install --upgrade jupyter

--- a/.github/workflows/html-validation.yml
+++ b/.github/workflows/html-validation.yml
@@ -52,15 +52,9 @@ jobs:
           bundler-cache: true
 
       - name: Update _config.yml
-        uses: fjogeleit/yaml-update-action@v0.16.1
-        with:
-          commitChange: false
-          valueFile: "_config.yml"
-          changes: |
-            {
-              "giscus.repo": "${{ github.repository }}",
-              "baseurl": ""
-            }
+        run: |
+          sed -i "s|^  repo:.*|  repo: ${{ github.repository }}|" _config.yml
+          sed -i "s|^baseurl:.*|baseurl: |" _config.yml
 
       - name: Install and Build
         run: |


### PR DESCRIPTION
## Summary

Replace `fjogeleit/yaml-update-action@v0.16.1` (Node.js 20) with simple `sed` commands across all 4 workflows that use it. This eliminates the Node.js 20 deprecation warning.

**Before:** Used a third-party GitHub Action just to update 1-2 YAML values in `_config.yml`
**After:** Two `sed` commands that do the same thing with zero dependencies

### Files changed
- `deploy.yml` — replace yaml-update-action with sed (giscus.repo only)
- `axe.yml` — replace yaml-update-action with sed (giscus.repo + baseurl)
- `broken-links-site.yml` — same
- `html-validation.yml` — same
- `deploy.yml` — also clean up path excludes for deleted workflows

## Test plan

- [ ] Deploy check passes (the sed correctly updates giscus.repo)
- [ ] No Node.js 20 deprecation warnings in annotations
- [ ] Prettier check passes
- [ ] Link checker passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)