### PR TITLE
Fix broken-links-site: use --root-dir flag for lychee v2

### DIFF
--- a/.github/workflows/broken-links-site.yml
+++ b/.github/workflows/broken-links-site.yml
@@ -37,4 +37,4 @@ jobs:
         with:
           fail: true
           # only check local links; --root requires base path for resolving root-relative URLs
-          args: --offline --root _site --remap '_site(/?.*)/assets/(.*) _site/assets/$2' --verbose --no-progress '_site/**/*.html'
+          args: --offline --root-dir _site --remap '_site(/?.*)/assets/(.*) _site/assets/$2' --verbose --no-progress '_site/**/*.html'


### PR DESCRIPTION
## Summary

Fix the 'Check for broken links on site' workflow — lychee v2.8.0 renamed `--root` to `--root-dir`. One character fix.

## Test plan

- [ ] broken-links-site workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)